### PR TITLE
Missing attribute functions

### DIFF
--- a/curses.go
+++ b/curses.go
@@ -75,6 +75,18 @@ func Attrset(attr int) {
 	C.attrset(C.int(attr))
 }
 
+func (win *Window) Attron(attr int) {
+	C.wattron((*C.WINDOW)(win), C.int(attr))
+}
+
+func (win *Window) Attroff(attr int) {
+	C.wattroff((*C.WINDOW)(win), C.int(attr))
+}
+
+func (win *Window) Attrset(attr int) {
+	C.wattrset((*C.WINDOW)(win), C.int(attr))
+}
+
 // Refresh screen.
 func Refresh() {
     C.refresh()


### PR DESCRIPTION
Hey, curses.go was missing bindings for the following functions:
- attrset
- wattron
- wattroff
- wattrset

The wattr\* stuff is necessary to set attributes on text rendered in windows -- using the normal attr\* functions doesn't work.

Thanks for the awesome library <3
